### PR TITLE
Update jtreceval dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,11 +122,10 @@
 			</exclusions>
 		</dependency>
 		<dependency>
-			<groupId>uk.ac.gla.dcs.terrierteam</groupId>
+			<groupId>com.github.mam10eks</groupId>
 			<artifactId>jtreceval</artifactId>
-			<version>0.0.5-SNAPSHOT-MF</version>
+			<version>8e8dbe0f26</version>
 		</dependency>
-
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
@@ -249,6 +248,10 @@
 		<repository>
 			<id>spark-packages</id>
 			<url>https://dl.bintray.com/spark-packages/maven/</url>
+		</repository>
+		<repository>
+			<id>jitpack.io</id>
+			<url>https://jitpack.io</url>
 		</repository>
 	</repositories>
 </project>


### PR DESCRIPTION
Removes the hard-coded local dependency to `jtreceval` in favor of referencing the artifact via jitpack.io
The `third-party` module could be removed now.